### PR TITLE
chore: #4 - Use ANTHROPIC_MODEL for model

### DIFF
--- a/adws/README.md
+++ b/adws/README.md
@@ -13,6 +13,7 @@ export AWS_REGION="eu-west-3"
 export CLAUDE_CODE_USE_BEDROCK="true"
 export CLAUDE_CODE_PATH="/path/to/claude"  # Optional, defaults to "claude"
 export GITHUB_PAT="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  # Optional, only if using different account than 'gh auth login'
+export ANTHROPIC_MODEL="us.anthropic.claude-3-5-sonnet-20241022-v2:0"  # Optional, defaults to Sonnet 3.5
 ```
 
 ### 2. Install Prerequisites
@@ -219,9 +220,22 @@ Each workflow run gets a unique 8-character ID (e.g., `a1b2c3d4`) that appears i
 - Git commits and PRs
 
 ### Model Selection
-Edit `agent.py` line 129 to change model:
-- `model="sonnet"` - Faster, lower cost (default)
-- `model="opus"` - Better for complex tasks
+Configure the model using the `ANTHROPIC_MODEL` environment variable:
+```bash
+# Default (Claude 3.5 Sonnet)
+export ANTHROPIC_MODEL="us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+# Claude 3.5 Haiku (faster, lower cost)
+export ANTHROPIC_MODEL="us.anthropic.claude-3-5-haiku-20241022-v1:0"
+
+# Claude Opus 4 (best for complex tasks)
+export ANTHROPIC_MODEL="us.anthropic.claude-opus-4-20250514-v1:0"
+
+# European region models
+export ANTHROPIC_MODEL="eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+```
+
+The model ARN must be a valid AWS Bedrock model identifier. If not set, defaults to Claude 3.5 Sonnet.
 
 ### Output Structure
 ```

--- a/adws/adw_plan_build.py
+++ b/adws/adw_plan_build.py
@@ -48,7 +48,7 @@ from github import (
     mark_issue_in_progress,
     get_repo_url,
 )
-from utils import make_adw_id, setup_logger
+from utils import make_adw_id, setup_logger, get_default_model
 
 # Agent name constants
 AGENT_PLANNER = "sdlc_planner"
@@ -123,7 +123,7 @@ def classify_issue(
         slash_command="/classify_issue",
         args=[issue.model_dump_json(indent=2, by_alias=True)],
         adw_id=adw_id,
-        model="sonnet",
+        model=get_default_model(),
     )
 
     logger.debug(
@@ -159,7 +159,7 @@ def build_plan(
         slash_command=command,
         args=[issue.title + ": " + issue.body],
         adw_id=adw_id,
-        model="sonnet",
+        model=get_default_model(),
     )
 
     logger.debug(
@@ -185,7 +185,7 @@ def get_plan_file(
         slash_command="/find_plan_file",
         args=[plan_output],
         adw_id=adw_id,
-        model="sonnet",
+        model=get_default_model(),
     )
 
     response = execute_template(request)
@@ -215,7 +215,7 @@ def implement_plan(
         slash_command="/implement",
         args=[plan_file],
         adw_id=adw_id,
-        model="sonnet",
+        model=get_default_model(),
     )
 
     logger.debug(
@@ -247,7 +247,7 @@ def git_branch(
         slash_command="/generate_branch_name",
         args=[issue_type, adw_id, issue.model_dump_json(by_alias=True)],
         adw_id=adw_id,
-        model="sonnet",
+        model=get_default_model(),
     )
 
     response = execute_template(request)
@@ -280,7 +280,7 @@ def git_commit(
         slash_command="/commit",
         args=[agent_name, issue_type, issue.model_dump_json(by_alias=True)],
         adw_id=adw_id,
-        model="sonnet",
+        model=get_default_model(),
     )
 
     response = execute_template(request)
@@ -307,7 +307,7 @@ def pull_request(
         slash_command="/pull_request",
         args=[branch_name, issue.model_dump_json(by_alias=True), plan_file, adw_id],
         adw_id=adw_id,
-        model="sonnet",
+        model=get_default_model(),
     )
 
     response = execute_template(request)

--- a/adws/data_types.py
+++ b/adws/data_types.py
@@ -106,7 +106,7 @@ class AgentPromptRequest(BaseModel):
     prompt: str
     adw_id: str
     agent_name: str = "ops"
-    model: Literal["sonnet", "opus"] = "opus"
+    model: str = "us.anthropic.claude-opus-4-20250514-v1:0"
     dangerously_skip_permissions: bool = False
     output_file: str
 
@@ -126,7 +126,7 @@ class AgentTemplateRequest(BaseModel):
     slash_command: SlashCommand
     args: List[str]
     adw_id: str
-    model: Literal["sonnet", "opus"] = "sonnet"
+    model: str = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
 
 
 class ClaudeCodeResultMessage(BaseModel):

--- a/adws/health_check.py
+++ b/adws/health_check.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel
 
 # Import git repo functions from github module
 from github import get_repo_url, extract_repo_path, make_issue_comment
+from utils import get_default_model
 
 # Load environment variables
 load_dotenv()
@@ -167,8 +168,8 @@ def check_claude_code() -> CheckResult:
         ) as tmp:
             output_file = tmp.name
 
-        # Run Claude Code - use ANTHROPIC_MODEL from env if set
-        model = os.getenv("ANTHROPIC_MODEL", "us.anthropic.claude-3-5-haiku-20241022-v1:0")
+        # Run Claude Code - use ANTHROPIC_MODEL from env or default
+        model = get_default_model()
         cmd = [
             claude_path,
             "-p",

--- a/adws/specs/use-anthropic-model-env-var-plan.md
+++ b/adws/specs/use-anthropic-model-env-var-plan.md
@@ -1,0 +1,90 @@
+# Chore: Use ANTHROPIC_MODEL Environment Variable for Model Configuration
+
+## Chore Description
+Ensure that the ANTHROPIC_MODEL environment variable is used consistently throughout the codebase wherever a model is specified. Currently, the code has hardcoded model values ("sonnet", "opus") in multiple places. This chore will:
+
+1. Update all hardcoded model references to use the ANTHROPIC_MODEL environment variable
+2. Provide sensible defaults when ANTHROPIC_MODEL is not set
+3. Ensure the model configuration is centralized and configurable
+4. Update data types to support flexible model specifications
+
+The ANTHROPIC_MODEL environment variable should contain the full Bedrock model ARN (e.g., "us.anthropic.claude-3-5-haiku-20241022-v1:0" or "eu.anthropic.claude-sonnet-4-5-20250929-v1:0") and be used instead of the simplified "sonnet"/"opus" literals.
+
+## Relevant Files
+Use these files to resolve the chore:
+
+- **adws/adw_plan_build.py** (Lines 126, 162, 188, 218, 250, 283, 310) - Contains 7 hardcoded `model="sonnet"` references in various agent template requests. These need to be updated to use ANTHROPIC_MODEL from the environment.
+
+- **adws/data_types.py** (Lines 109, 129) - Defines model types as `Literal["sonnet", "opus"]` which restricts the model values. These type definitions need to be updated to accept any string value to support full Bedrock model ARNs.
+
+- **adws/agent.py** (Line 108, 259) - Reads ANTHROPIC_MODEL from environment and passes it to Claude Code CLI. This file already handles ANTHROPIC_MODEL correctly, but we should verify it's being used properly.
+
+- **adws/health_check.py** (Line 171) - Uses ANTHROPIC_MODEL with a default value of "us.anthropic.claude-3-5-haiku-20241022-v1:0". This is a good reference implementation.
+
+- **README.md** (Lines 222-224) - Documentation mentions editing agent.py to change model. This documentation needs to be updated to reference the ANTHROPIC_MODEL environment variable instead.
+
+### New Files
+No new files need to be created for this chore.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update data_types.py to Support Flexible Model Specification
+- Change `model: Literal["sonnet", "opus"]` to `model: str` in `AgentPromptRequest` (line 109)
+- Change `model: Literal["sonnet", "opus"]` to `model: str` in `AgentTemplateRequest` (line 129)
+- Update default values from `"opus"` and `"sonnet"` to use a sensible Bedrock model ARN
+- This removes the restriction on model values and allows full Bedrock model ARNs
+
+### Step 2: Create Helper Function for Model Resolution
+- Add a helper function `get_default_model()` in `adws/utils.py` that:
+  - Reads ANTHROPIC_MODEL from environment
+  - Returns a default Bedrock model ARN if not set (e.g., "us.anthropic.claude-3-5-sonnet-20241022-v2:0")
+  - Provides a single source of truth for model configuration
+- This centralizes the model resolution logic
+
+### Step 3: Update adw_plan_build.py to Use Environment Variable
+- Import the helper function from utils.py
+- Replace all 7 hardcoded `model="sonnet"` occurrences with `model=get_default_model()`
+- This affects the following functions:
+  - `classify_issue()` - line 126
+  - `build_plan()` - line 162
+  - `get_plan_file()` - line 188
+  - `implement_plan()` - line 218
+  - `git_branch()` - line 250
+  - `git_commit()` - line 283
+  - `pull_request()` - line 310
+
+### Step 4: Update health_check.py for Consistency
+- Import the helper function from utils.py
+- Replace the hardcoded default in line 171 with a call to `get_default_model()`
+- This ensures consistent model defaults across the codebase
+
+### Step 5: Update README.md Documentation
+- Update the "Model Selection" section (lines 222-224) to explain the ANTHROPIC_MODEL environment variable
+- Remove references to editing agent.py directly
+- Add documentation about setting ANTHROPIC_MODEL in the environment
+- Include examples of valid Bedrock model ARNs
+- Update the "Set Environment Variables" section to include ANTHROPIC_MODEL as an optional variable
+
+### Step 6: Run Validation Commands
+- Execute all validation commands to ensure no regressions
+- Verify that the changes work correctly with different model configurations
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `cd /workspace/projects/Learning/tac-4/adws && python3 -m py_compile adws/data_types.py` - Validate data_types.py syntax
+- `cd /workspace/projects/Learning/tac-4/adws && python3 -m py_compile adws/utils.py` - Validate utils.py syntax
+- `cd /workspace/projects/Learning/tac-4/adws && python3 -m py_compile adws/adw_plan_build.py` - Validate adw_plan_build.py syntax
+- `cd /workspace/projects/Learning/tac-4/adws && python3 -m py_compile adws/health_check.py` - Validate health_check.py syntax
+- `cd /workspace/projects/Learning/tac-4/adws && python3 -m py_compile adws/agent.py` - Validate agent.py syntax
+- `cd /workspace/projects/Learning/tac-4/adws && python3 -c "from data_types import AgentPromptRequest, AgentTemplateRequest; print('Data types import successfully')"` - Validate data types can be imported
+- `cd /workspace/projects/Learning/tac-4/adws && python3 -c "from utils import get_default_model; print('Model:', get_default_model())"` - Validate the helper function works
+
+## Notes
+- The ANTHROPIC_MODEL environment variable is already being read by agent.py (line 108) and passed to the Claude Code CLI execution environment
+- health_check.py already demonstrates the correct pattern for using ANTHROPIC_MODEL with a default fallback
+- The change from Literal["sonnet", "opus"] to str is necessary because Bedrock model ARNs are full strings like "us.anthropic.claude-3-5-haiku-20241022-v1:0", not just "sonnet" or "opus"
+- The helper function in utils.py will provide a single source of truth for model configuration and make future changes easier
+- This change makes the system more flexible and allows users to specify any Bedrock model via environment variable
+- After this chore is complete, users can control which model is used by setting ANTHROPIC_MODEL in their .env file, without needing to modify code

--- a/adws/utils.py
+++ b/adws/utils.py
@@ -12,6 +12,15 @@ def make_adw_id() -> str:
     return str(uuid.uuid4())[:8]
 
 
+def get_default_model() -> str:
+    """Get the default Bedrock model ARN from environment or return a sensible default.
+
+    Returns:
+        Bedrock model ARN string (e.g., 'us.anthropic.claude-3-5-sonnet-20241022-v2:0')
+    """
+    return os.getenv("ANTHROPIC_MODEL", "us.anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+
 def setup_logger(adw_id: str, trigger_type: str = "adw_plan_build") -> logging.Logger:
     """Set up logger that writes to both console and file using adw_id.
     


### PR DESCRIPTION
## Summary

This PR implements the changes required by issue #4 to use the `ANTHROPIC_MODEL` environment variable consistently throughout the codebase instead of hardcoded model values.

## Implementation Plan

See [use-anthropic-model-env-var-plan.md](specs/use-anthropic-model-env-var-plan.md) for the detailed implementation plan.

## Changes Made

- ✅ Updated `data_types.py` to change model type from `Literal["sonnet", "opus"]` to `str` to support full Bedrock model ARNs
- ✅ Created `get_default_model()` helper function in `utils.py` to centralize model configuration
- ✅ Updated all 7 hardcoded `model="sonnet"` references in `adw_plan_build.py` to use `get_default_model()`
- ✅ Updated `health_check.py` to use the centralized helper function
- ✅ Updated `README.md` documentation to explain the `ANTHROPIC_MODEL` environment variable usage
- ✅ All validation commands passed successfully

## Files Changed

- `adws/data_types.py` - Updated model types to accept any string value
- `adws/utils.py` - Added `get_default_model()` helper function
- `adws/adw_plan_build.py` - Replaced hardcoded model values with environment-based configuration
- `adws/health_check.py` - Updated to use centralized model resolution
- `adws/README.md` - Updated documentation for ANTHROPIC_MODEL usage
- `adws/specs/use-anthropic-model-env-var-plan.md` - Added implementation plan

## Testing

All validation commands have been executed and passed:
- Python syntax validation for all modified files
- Import validation for updated data types
- Helper function validation

Closes #4

---
**ADW Tracking ID:** 51e16286